### PR TITLE
Added a close method to release resource

### DIFF
--- a/src/Miner.js
+++ b/src/Miner.js
@@ -118,6 +118,7 @@ class Miner extends Nimiq.Observable {
 
     stop() {
         this._miningEnabled = false;
+        this._miner.close();        
         if (this._hashRateTimer) {
             this._hashes = [];
             this._lastHashRates = [];


### PR DESCRIPTION
Added a close() method to the native miner. 

This is needed in an interactive usage as the miner can be stopped and started multiple times. Tested multiple times in the desktop miner, and everything works fine.